### PR TITLE
Send proper Accept HTTP header

### DIFF
--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -179,6 +179,9 @@ class Client {
       'redirect_uri' => $redirectURI,
       'client_id' => $clientID
     )));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        'Accept: application/json, application/x-www-form-urlencoded;q=0.8'
+    ));
     $response = curl_exec($ch);
 
     $auth = json_decode($response, true);
@@ -211,6 +214,9 @@ class Client {
       'redirect_uri' => $redirectURI,
       'client_id' => $clientID
     )));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        'Accept: application/json, application/x-www-form-urlencoded;q=0.8'
+    ));
     $response = curl_exec($ch);
 
     $auth = json_decode($response, true);


### PR DESCRIPTION
My go at fixing #11.

When Client expects a specific content type back from the server, make sure to list it in the Accept header. For `getAccessToken` and `verifyIndieAuthCode` both JSON and form-encoded responses can be parsed so are both included in the Accept header. JSON is given as the preferred format.