### PR TITLE
Always use response_type=code

### DIFF
--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -331,11 +331,9 @@ class Client {
     $params['redirect_uri'] = $redirectURI;
     $params['client_id'] = $clientID;
     $params['state'] = $state;
+    $params['response_type'] = 'code';
     if($scope) {
       $params['scope'] = $scope;
-      $params['response_type'] = 'code';
-    } else {
-      $params['response_type'] = 'id';
     }
     if($codeVerifier) {
       $params['code_challenge'] = self::generatePKCECodeChallenge($codeVerifier);


### PR DESCRIPTION
Ever since the [spec change published on 2020-08-09](https://indieauth.spec.indieweb.org/#changes-from-25-january-2020-to-09-august-2020) the only valid, and required, value for response_type is code. This change makes sure that is the only value used by the client code. This should make spec compliance automatic for any implementations using this library.