### PR TITLE
Add support for IndieAuth metadata endpoint

### DIFF
--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -121,7 +121,7 @@ class Client {
       }
 
       if ($params['iss'] !== $_SESSION['indieauth_issuer']) {
-        return self::_errorResponse('invalid_iss', 'The authorization server return an invalid iss parameter');
+        return self::_errorResponse('invalid_iss', 'The authorization server returned an invalid iss parameter');
       }
     }
 

--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -157,9 +157,12 @@ class Client {
       return self::_errorResponse($error, $error_description, $data);
     }
 
-    // If the returned "me" is not the same as the entered "me", check that the authorization server linked to
+    // If the returned "me" is not the same as the entered "me", check that the authorization endpoint linked to
     // by the returned URL is the same as the one used
     if($_SESSION['indieauth_entered_url'] != $data['response']['me']) {
+      // Discover and populate metadata if the returned "me" has a metadata endpoint
+      $metadataEndpoint = self::discoverMetadataEndpoint($data['response']['me']);
+
       // Go find the authorization endpoint that the returned "me" URL declares
       $authorizationEndpoint = static::discoverAuthorizationEndpoint($data['response']['me']);
 

--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -290,12 +290,19 @@ class Client {
     }
   }
 
+  private static function resetMetadata() {
+    self::$_metadata_body = array();
+    self::$_metadata = null;
+  }
+
   /**
    * Set metadata body
    * $body is expected to be JSON and will attempt
    * to decode to array in self::$_metadata
    */
   public static function setMetadata($url, $body) {
+    self::resetMetadata();
+
     self::$_metadata_body[$url] = $body;
     $metadata_array = json_decode($body, true);
     if (!is_null($metadata_array)) {
@@ -383,6 +390,18 @@ class Client {
     return self::_discoverEndpoint($url, 'token_endpoint');
   }
 
+  public static function discoverRevocationEndpoint($url) {
+    return self::_discoverEndpoint($url, 'revocation_endpoint');
+  }
+
+  public static function discoverIntrospectionEndpoint($url) {
+    return self::_discoverEndpoint($url, 'introspection_endpoint');
+  }
+
+  public static function discoverUserinfoEndpoint($url) {
+    return self::_discoverEndpoint($url, 'userinfo_endpoint');
+  }
+
   public static function discoverMicropubEndpoint($url) {
     return self::_discoverEndpoint($url, 'micropub');
   }
@@ -464,7 +483,7 @@ class Client {
   }
 
   public static function build_url($parsed_url) {
-    $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+    $scheme   = isset($parsed_url['scheme']) ? strtolower($parsed_url['scheme']) . '://' : '';
     $host     = isset($parsed_url['host']) ? strtolower($parsed_url['host']) : '';
     $port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
     $user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';

--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -47,6 +47,8 @@ class Client {
       if (!($issuer && self::_isIssuerValid($issuer, $metadataEndpoint))) {
         return self::_errorResponse('invalid_issuer', 'Issuer in metadata endpoint is not valid');
       }
+
+      $_SESSION['indieauth_issuer'] = $issuer;
     }
 
     if(!$authorizationEndpoint) {
@@ -111,6 +113,16 @@ class Client {
 
     if($params['state'] != $_SESSION['indieauth_state']) {
       return self::_errorResponse('invalid_state', 'The authorization server returned an invalid state parameter');
+    }
+
+    if (isset($_SESSION['indieauth_issuer'])) {
+      if (!isset($params['iss'])) {
+        return self::_errorResponse('missing_iss', 'The authorization server did not return the iss parameter');
+      }
+
+      if ($params['iss'] !== $_SESSION['indieauth_issuer']) {
+        return self::_errorResponse('invalid_iss', 'The authorization server return an invalid iss parameter');
+      }
     }
 
     if(isset($_SESSION['indieauth_token_endpoint'])) {
@@ -182,6 +194,7 @@ class Client {
     unset($_SESSION['indieauth_code_verifier']);
     unset($_SESSION['indieauth_authorization_endpoint']);
     unset($_SESSION['indieauth_token_endpoint']);
+    unset($_SESSION['indieauth_issuer']);
   }
 
   public static function setUpHTTP() {

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -1,0 +1,102 @@
+<?php  
+
+class MetadataTest extends IndieAuthTestCase {
+
+  public function testGetMetadata() {
+    $json = '{"issuer":"https://example.com/","authorization_endpoint":"https://example.com/authorization-endpoint","token_endpoint":"https://example.com/token-endpoint"}';
+
+    IndieAuth\Client::setMetadata('https://example.com/', $json);
+    $metadata = IndieAuth\Client::getMetadata();
+
+    $this->assertInternalType('array', $metadata);
+    $this->assertArrayHasKey('issuer', $metadata);
+    $this->assertArrayHasKey('authorization_endpoint', $metadata);
+    $this->assertArrayHasKey('token_endpoint', $metadata);
+  }
+
+  public function testDiscoverFromMetadata() {
+    $json = '{"issuer":"https://example.com/","authorization_endpoint":"https://example.com/authorization-endpoint","token_endpoint":"https://example.com/token-endpoint"}';
+
+    IndieAuth\Client::setMetadata('https://example.com/', $json);
+
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_discoverFromMetadata',
+      ['issuer']
+    );
+
+    $this->assertEquals($result, 'https://example.com/');
+
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_discoverFromMetadata',
+      ['authorization_endpoint']
+    );
+
+    $this->assertEquals($result, 'https://example.com/authorization-endpoint');
+
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_discoverFromMetadata',
+      ['token_endpoint']
+    );
+
+    $this->assertEquals($result, 'https://example.com/token-endpoint');
+
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_discoverFromMetadata',
+      ['revocation_endpoint']
+    );
+
+    $this->assertNull($result);
+  }
+
+  public function testIsIssuerValid() {
+  	# scheme must be https
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_isIssuerValid',
+      ['http://example.com/', 'https://example.com/indieauth-metadata-endpoint']
+    );
+
+    $this->assertFalse($result);
+
+  	# no query string allowed
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_isIssuerValid',
+      ['https://example.com/?foo=bar', 'https://example.com/indieauth-metadata-endpoint']
+    );
+
+    $this->assertFalse($result);
+
+  	# no fragment allowed
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_isIssuerValid',
+      ['https://example.com/#issuer', 'https://example.com/indieauth-metadata-endpoint']
+    );
+
+    $this->assertFalse($result);
+
+  	# issuer must be prefix of metadata endpoint
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_isIssuerValid',
+      ['https://example.com/foo', 'https://example.com/indieauth-metadata-endpoint']
+    );
+
+    $this->assertFalse($result);
+
+  	# valid issuer
+    $result = $this->_invokeStaticMethod(
+      IndieAuth\Client::class,
+      '_isIssuerValid',
+      ['https://example.com/', 'https://example.com/indieauth-metadata-endpoint']
+    );
+
+    $this->assertTrue($result);
+  }
+
+}

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -53,7 +53,7 @@ class MetadataTest extends IndieAuthTestCase {
   }
 
   public function testIsIssuerValid() {
-  	# scheme must be https
+    # scheme must be https
     $result = $this->_invokeStaticMethod(
       IndieAuth\Client::class,
       '_isIssuerValid',
@@ -62,7 +62,7 @@ class MetadataTest extends IndieAuthTestCase {
 
     $this->assertFalse($result);
 
-  	# no query string allowed
+    # no query string allowed
     $result = $this->_invokeStaticMethod(
       IndieAuth\Client::class,
       '_isIssuerValid',
@@ -71,7 +71,7 @@ class MetadataTest extends IndieAuthTestCase {
 
     $this->assertFalse($result);
 
-  	# no fragment allowed
+    # no fragment allowed
     $result = $this->_invokeStaticMethod(
       IndieAuth\Client::class,
       '_isIssuerValid',
@@ -80,7 +80,7 @@ class MetadataTest extends IndieAuthTestCase {
 
     $this->assertFalse($result);
 
-  	# issuer must be prefix of metadata endpoint
+    # issuer must be prefix of metadata endpoint
     $result = $this->_invokeStaticMethod(
       IndieAuth\Client::class,
       '_isIssuerValid',
@@ -89,7 +89,7 @@ class MetadataTest extends IndieAuthTestCase {
 
     $this->assertFalse($result);
 
-  	# valid issuer
+    # valid issuer
     $result = $this->_invokeStaticMethod(
       IndieAuth\Client::class,
       '_isIssuerValid',

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -1,34 +1,48 @@
 <?php  
 
+use IndieAuth\Client;
+
 class MetadataTest extends IndieAuthTestCase {
 
-  public function testGetMetadata() {
-    $json = '{"issuer":"https://example.com/","authorization_endpoint":"https://example.com/authorization-endpoint","token_endpoint":"https://example.com/token-endpoint"}';
+  private $default_metadata = '{"issuer":"https://example.com/","authorization_endpoint":"https://example.com/authorization-endpoint","token_endpoint":"https://example.com/token-endpoint","revocation_endpoint":"https://example.com/revocation-endpoint","introspection_endpoint":"https://example.com/introspection-endpoint","userinfo_endpoint":"https://example.com/userinfo-endpoint"}';
 
-    IndieAuth\Client::setMetadata('https://example.com/', $json);
-    $metadata = IndieAuth\Client::getMetadata();
+  public function testSetAndGetMetadata() {
+    Client::setMetadata('https://example.com/', $this->default_metadata);
+    $metadata = Client::getMetadata();
 
     $this->assertInternalType('array', $metadata);
     $this->assertArrayHasKey('issuer', $metadata);
     $this->assertArrayHasKey('authorization_endpoint', $metadata);
     $this->assertArrayHasKey('token_endpoint', $metadata);
+    $this->assertArrayHasKey('revocation_endpoint', $metadata);
+    $this->assertArrayHasKey('introspection_endpoint', $metadata);
+  }
+
+  public function testSetMetadataInvalid() {
+    # malfored JSON
+    Client::setMetadata('https://example.com/', '{"issuer":"https://example.com/');
+    $metadata = Client::getMetadata();
+    $this->assertNull($metadata);
+
+    # other content like HTML
+    Client::setMetadata('https://example.com/', '<p> invalid metdata </p>');
+    $metadata = Client::getMetadata();
+    $this->assertNull($metadata);
   }
 
   public function testDiscoverFromMetadata() {
-    $json = '{"issuer":"https://example.com/","authorization_endpoint":"https://example.com/authorization-endpoint","token_endpoint":"https://example.com/token-endpoint"}';
-
-    IndieAuth\Client::setMetadata('https://example.com/', $json);
+    Client::setMetadata('https://example.com/', $this->default_metadata);
 
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_discoverFromMetadata',
       ['issuer']
     );
 
-    $this->assertEquals($result, 'https://example.com/');
+    $this->assertEquals('https://example.com/', $result);
 
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_discoverFromMetadata',
       ['authorization_endpoint']
     );
@@ -36,26 +50,42 @@ class MetadataTest extends IndieAuthTestCase {
     $this->assertEquals($result, 'https://example.com/authorization-endpoint');
 
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_discoverFromMetadata',
       ['token_endpoint']
     );
 
-    $this->assertEquals($result, 'https://example.com/token-endpoint');
+    $this->assertEquals('https://example.com/token-endpoint', $result);
 
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_discoverFromMetadata',
       ['revocation_endpoint']
     );
 
-    $this->assertNull($result);
+    $this->assertEquals('https://example.com/revocation-endpoint', $result);
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      '_discoverFromMetadata',
+      ['introspection_endpoint']
+    );
+
+    $this->assertEquals('https://example.com/introspection-endpoint', $result);
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      '_discoverFromMetadata',
+      ['userinfo_endpoint']
+    );
+
+    $this->assertEquals('https://example.com/userinfo-endpoint', $result);
   }
 
   public function testIsIssuerValid() {
     # scheme must be https
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_isIssuerValid',
       ['http://example.com/', 'https://example.com/indieauth-metadata-endpoint']
     );
@@ -64,7 +94,7 @@ class MetadataTest extends IndieAuthTestCase {
 
     # no query string allowed
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_isIssuerValid',
       ['https://example.com/?foo=bar', 'https://example.com/indieauth-metadata-endpoint']
     );
@@ -73,7 +103,7 @@ class MetadataTest extends IndieAuthTestCase {
 
     # no fragment allowed
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_isIssuerValid',
       ['https://example.com/#issuer', 'https://example.com/indieauth-metadata-endpoint']
     );
@@ -82,7 +112,7 @@ class MetadataTest extends IndieAuthTestCase {
 
     # issuer must be prefix of metadata endpoint
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_isIssuerValid',
       ['https://example.com/foo', 'https://example.com/indieauth-metadata-endpoint']
     );
@@ -91,12 +121,48 @@ class MetadataTest extends IndieAuthTestCase {
 
     # valid issuer
     $result = $this->_invokeStaticMethod(
-      IndieAuth\Client::class,
+      Client::class,
       '_isIssuerValid',
       ['https://example.com/', 'https://example.com/indieauth-metadata-endpoint']
     );
 
     $this->assertTrue($result);
+  }
+
+  public function testDiscoverRevocationEndpoint() {
+    Client::setMetadata('https://example.com/', $this->default_metadata);
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      'discoverRevocationEndpoint',
+      ['https://example.com/']
+    );
+
+    $this->assertEquals('https://example.com/revocation-endpoint', $result);
+  }
+
+  public function testDiscoverIntrospectionEndpoint() {
+    Client::setMetadata('https://example.com/', $this->default_metadata);
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      'discoverIntrospectionEndpoint',
+      ['https://example.com/']
+    );
+
+    $this->assertEquals('https://example.com/introspection-endpoint', $result);
+  }
+
+  public function testDiscoverUserinfoEndpoint() {
+    Client::setMetadata('https://example.com/', $this->default_metadata);
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      'discoverUserinfoEndpoint',
+      ['https://example.com/']
+    );
+
+    $this->assertEquals('https://example.com/userinfo-endpoint', $result);
   }
 
 }


### PR DESCRIPTION
- Adds `discoverMetadataEndpoint()`: if a metadata endpoint is found, this fetches the JSON, stores it, stores a decoded PHP array version, and returns the metadata endpoint
    - Adds `setMetadata()`, `getMetadata()`, and `resetMetadata()` for this and for easier unit testing
- Adds `discoverRevocationEndpoint()`, `discoverIntrospectionEndpoint()`, and
`discoverUserinfoEndpoint()` methods
- If metadata endpoint is found, checks for `issuer` in the body and ensures it's valid with `_isIssuerValid()`; returns `invalid_issuer` error message if it isn't.
- `_discoverEndpoint()` updated to first check for endpoints in the parsed metadata with `_discoverFromMetadata()`, then continues to check in HTTP headers and rel links if not found
- `build_url()` updated to ensure scheme and hostname are lowercased for URL normalization
- Adds MetadataTest.php with unit tests for these changes
- Some minor syntax improvements, adding braces on one-line if conditions