### PR TITLE
Add methods for manual IndieAuth process

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ if ($metadataEndpoint) {
   $response = self::discoverIssuer($metadataEndpoint);
   if ($response instanceof IndieAuth\ErrorResponse) {
     // handle the error response, array with keys `error` and `error_description`
-    die($response->getArray());
+    die(json_encode($response->getArray()));
   }
 
   $_SESSION['indieauth_issuer'] = $response;
@@ -373,14 +373,14 @@ Next, the `state` and `iss` parameters must be verified to match the authorizati
 $response = self::validateStateMatch($_GET, $_SESSION['indieauth_state']);
 if ($response instanceof ErrorResponse) {
   // handle the error response, array with keys `error` and `error_description`
-  die($response->getArray());
+  die(json_encode($response->getArray()));
 }
 
 if (isset($_SESSION['indieauth_issuer'])) {
   $response = self::validateIssuerMatch($_GET, $_SESSION['indieauth_issuer']);
   if ($response instanceof ErrorResponse) {
     // handle the error response, array with keys `error` and `error_description`
-    die($response->getArray());
+    die(json_encode($response->getArray()));
   }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     }
   ],
   "autoload": {
-    "psr-0": {
-      "IndieAuth": "src/"
+    "psr-4": {
+      "IndieAuth\\": "src/IndieAuth/"
     }
   },
   "require-dev": {

--- a/src/IndieAuth/ErrorResponse.php
+++ b/src/IndieAuth/ErrorResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace IndieAuth;
+
+class ErrorResponse
+{
+  private $code;
+  private $description;
+  private $debug;
+
+  public function __construct($code, $description, $debug = null)
+  {
+    $this->code = $code;
+    $this->description = $description;
+    $this->debug = $debug;
+  }
+
+  /**
+   * @return array
+   */
+  public function getArray()
+  {
+    $response = [
+      'error' => $this->code,
+      'error_description' => $this->description,
+    ];
+
+    if ($this->debug) {
+      $response['debug'] = $this->debug;
+    }
+
+    return [false, $response];
+  }
+}
+

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,94 @@
+<?php  
+/**
+ * General IndieAuth Client tests
+ */
+
+use IndieAuth\Client;
+use IndieAuth\ErrorResponse;
+
+class ClientTest extends IndieAuthTestCase
+{
+  public function setUp(): void
+  {
+    if (!isset($_SESSION)) {
+      $_SESSION = [];
+    }
+  }
+
+  public function testErrorResponse()
+  {
+    $object = new ErrorResponse('missing_state', 'The state is missing', 'debug information');
+    $result = $object->getArray();
+
+    $this->assertIsArray($result);
+    $this->assertCount(2, $result);
+
+    if (isset($result[1])) {
+      $error = $result[1];
+      $this->assertIsArray($error);
+      $this->assertCount(3, $error);
+
+      $this->assertArrayHasKey('error', $error);
+      $this->assertArrayHasKey('error_description', $error);
+      $this->assertArrayHasKey('debug', $error);
+
+      $this->assertEquals('missing_state', $error['error']);
+      $this->assertEquals('The state is missing', $error['error_description']);
+      $this->assertEquals('debug information', $error['debug']);
+    }
+  }
+
+  public function testValidateState()
+  {
+    $expected_state = 'example_state';
+    $params = ['state' => $expected_state];
+    $response = Client::validateStateMatch($params, $expected_state);
+    $this->assertNull($response);
+  }
+
+  public function testValidateStateCase()
+  {
+    $params = ['state' => 'example_state'];
+    $response = Client::validateStateMatch($params, 'Example_State');
+    $this->assertInstanceOf(ErrorResponse::class, $response);
+  }
+
+  public function testValidateStateMissing()
+  {
+    $params = [];
+    $response = Client::validateStateMatch($params, 'state');
+    $this->assertInstanceOf(ErrorResponse::class, $response);
+  }
+
+  public function testValidateStateMismatch()
+  {
+    $params = ['state' => 'example_state'];
+    $response = Client::validateStateMatch($params, 'unexpected_state');
+    $this->assertInstanceOf(ErrorResponse::class, $response);
+  }
+
+  public function testValidateIssuer()
+  {
+    $expected_issuer = 'https://issuer.example.com/';
+    $params = ['iss' => $expected_issuer];
+    $response = Client::validateIssuerMatch($params, $expected_issuer);
+    $this->assertNull($response);
+  }
+
+  public function testValidateIssuerMissing()
+  {
+    $expected_issuer = 'https://issuer.example.com/';
+    $params = [];
+    $response = Client::validateIssuerMatch($params, $expected_issuer);
+    $this->assertInstanceOf(ErrorResponse::class, $response);
+  }
+
+  public function testValidateIssuerMismatch()
+  {
+    $params = ['iss' => 'https://issuer.example.com/'];
+    $response = Client::validateIssuerMatch($params, 'https://example.org/');
+    $this->assertInstanceOf(ErrorResponse::class, $response);
+  }
+
+}
+

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -1,6 +1,7 @@
 <?php  
 
 use IndieAuth\Client;
+use IndieAuth\ErrorResponse;
 
 class MetadataTest extends IndieAuthTestCase {
 
@@ -127,6 +128,51 @@ class MetadataTest extends IndieAuthTestCase {
     );
 
     $this->assertTrue($result);
+  }
+
+  public function testDiscoverIssuer()
+  {
+    Client::setMetadata('https://example.com/', $this->default_metadata);
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      'discoverIssuer',
+      ['https://example.com/indieauth-metadata-endpoint']
+    );
+
+    $this->assertEquals('https://example.com/', $result);
+  }
+
+  /**
+   * `issuer` must be provided in indieauth-metadata
+   */
+  public function testDiscoverIssuerMissing()
+  {
+    Client::setMetadata('https://example.com/', '{"authorization_endpoint":"https://example.com/authorization-endpoint"}');
+    $metadata_endpoint = 'https://example.com/indieauth-metadata-endpoint';
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      'discoverIssuer',
+      [$metadata_endpoint]
+    );
+    $this->assertInstanceOf(ErrorResponse::class, $result);
+  }
+
+  /**
+   * `issuer` must be a prefix of the metadata endpoint
+   */
+  public function testDiscoverIssuerNotAPrefix()
+  {
+    Client::setMetadata('https://example.org/', $this->default_metadata);
+    $metadata_endpoint = 'https://example.org/indieauth-metadata-endpoint';
+
+    $result = $this->_invokeStaticMethod(
+      Client::class,
+      'discoverIssuer',
+      [$metadata_endpoint]
+    );
+    $this->assertInstanceOf(ErrorResponse::class, $result);
   }
 
   public function testDiscoverRevocationEndpoint() {


### PR DESCRIPTION
- Add methods: discoverIssuer(), validateStateMatch(), validateIssuerMatch()
- Use PSR-4 instead of PSR-0 in composer.json
- Use class constant for version number
- Add `ErrorResponse` class so manual IndieAuth implementations can more easily respond to errors using `instanceof`
- Make existing _errorResponse() method a wrapper around the ErrorResponse class
- Update README to include IndieAuth Metadata discovery and all new methods
- Add/update unit tests

Closes #23 