### PR TITLE
Pass along 'me' URI to authn/token endpoints

### DIFF
--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -117,14 +117,14 @@ class Client {
     }
 
     if(isset($_SESSION['indieauth_token_endpoint'])) {
-      $data = self::exchangeAuthorizationCode($_SESSION['indieauth_token_endpoint'], [
+      $data = self::exchangeAuthorizationCode($_SESSION['indieauth_token_endpoint'].'?me='.$params['me'], [
         'code' => $params['code'],
         'redirect_uri' => self::$redirectURL,
         'client_id' => self::$clientID,
         'code_verifier' => $_SESSION['indieauth_code_verifier'],
       ]);
     } else {
-      $data = self::exchangeAuthorizationCode($_SESSION['indieauth_authorization_endpoint'], [
+      $data = self::exchangeAuthorizationCode($_SESSION['indieauth_authorization_endpoint'].'?me='.$params['me'], [
         'code' => $params['code'],
         'redirect_uri' => self::$redirectURL,
         'client_id' => self::$clientID,


### PR DESCRIPTION
MinToken (https://github.com/Zegnat/php-mintoken) requires this value to be present in the query string or it will fail.