### PR TITLE
normalize issuer as a sanity check

### DIFF
--- a/src/IndieAuth/Client.php
+++ b/src/IndieAuth/Client.php
@@ -535,7 +535,7 @@ class Client {
       return new ErrorResponse('missing_iss', 'The authorization server did not return the iss parameter');
     }
 
-    if ($params['iss'] !== $expected_issuer) {
+    if (self::normalizeMeURL($params['iss']) !== self::normalizeMeURL($expected_issuer)) {
       return new ErrorResponse('invalid_iss', 'The authorization server returned an invalid iss parameter');
     }
   }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -75,6 +75,14 @@ class ClientTest extends IndieAuthTestCase
     $this->assertNull($response);
   }
 
+  public function testValidateIssuerNormalizes()
+  {
+    $expected_issuer = 'https://issuer.example.com';
+    $params = ['iss' => $expected_issuer];
+    $response = Client::validateIssuerMatch($params, $expected_issuer.'/');
+    $this->assertNull($response);
+  }
+
   public function testValidateIssuerMissing()
   {
     $expected_issuer = 'https://issuer.example.com/';


### PR DESCRIPTION
Inexperienced devs/users may not know whether to include a final slash (/) at the end of their issuer field in their metadata endpoint. Also, it seems some OIDC/OAuth modules may require there to NOT be a final slash (/) at the end of the issuer.

This change is intended to make it less error prone overall.